### PR TITLE
Update Chart.yaml

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -2,6 +2,6 @@ chart-dirs:
   - helm-charts/charts
 
 chart-repos:
-  - bitnami=bitnami=https://charts.bitnami.com/bitnami
+  - bitnami=https://charts.bitnami.com/bitnami
 
 validate-maintainers: false

--- a/ct.yaml
+++ b/ct.yaml
@@ -2,6 +2,6 @@ chart-dirs:
   - helm-charts/charts
 
 chart-repos:
-  - bitnami=https://charts.bitnami.com
+  - bitnami=bitnami=https://charts.bitnami.com/bitnami
 
 validate-maintainers: false

--- a/helm-charts/charts/guestbook/Chart.yaml
+++ b/helm-charts/charts/guestbook/Chart.yaml
@@ -23,4 +23,4 @@ appVersion: v4
 dependencies:
   - name: redis
     version: 10.5.x
-    repository: https://charts.bitnami.com
+    repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
bitnami chart repository moved to a  new location.
old url is invalid and causes helm to fail